### PR TITLE
Make it possible to create entities through UI without multilingual support.

### DIFF
--- a/src/Entity/Log.php
+++ b/src/Entity/Log.php
@@ -71,7 +71,7 @@ class Log extends ContentEntityBase implements LogInterface {
 
   protected $tokenService;
 
-  public function __construct(array $values, $entity_type, $bundle, array $translations) {
+  public function __construct(array $values, $entity_type, $bundle, array $translations = []) {
     parent::__construct($values, $entity_type, $bundle, $translations);
     $this->tokenService = \Drupal::token();
   }


### PR DESCRIPTION
Got this error otherwise:

```
Recoverable fatal error: Argument 4 passed to Drupal\log\Entity\Log::__construct() must be of the type array, none given
```
