### PR TITLE
Allow access to bulk delete if a user can delete own or any log entities.

### DIFF
--- a/log.routing.yml
+++ b/log.routing.yml
@@ -47,4 +47,4 @@ log.multiple_delete_confirm:
   defaults:
     _form: '\Drupal\log\Form\DeleteMultiple'
   requirements:
-    _permission: 'administer log types'
+    _custom_access: '\Drupal\log\Form\DeleteMultiple::access'


### PR DESCRIPTION
Right now only a user with administer log types permission can access the batch delete confirm page. If we want to provide an interface where a user can bulk operate on entities he has created, he can only delete one and one, not batch delete.

This PR fixes that.

Should probably add a test also, but since the bulk part does not have any tests, I skipped it :p
